### PR TITLE
Add the ability to filter errors by environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,15 @@ Installation & Usage
 2.  Install puppet-xmpp as a module in your Puppet master's module
     path.
 
-3.  Update the `xmpp_jid`, `xmpp_passowrd`, and `xmpp_target` variables in `xmpp.yaml` 
+3.  Update the `xmpp_jid`, `xmpp_passowrd`, and `xmpp_target` variables in `xmpp.yaml`
     and copy the file to `/etc/puppet`. An example file is included.
 
-4.  Enable pluginsync and reports on your master and clients in `puppet.conf`
+4.  Optionally change `xmpp_environment` in `xmpp.yaml`.  You can set this value to a
+    string or an array of strings.  These strings are the names of acceptable environments
+    to send alerts for.  If you don't change this option from the default of ALL the
+    processor will send an alert for errors in all environments.
+
+5.  Enable pluginsync and reports on your master and clients in `puppet.conf`
 
         [master]
         report = true
@@ -36,7 +41,7 @@ Installation & Usage
         report = true
         pluginsync = true
 
-5.  Run the Puppet client and sync the report as a plugin
+6.  Run the Puppet client and sync the report as a plugin
 
 Author
 ------

--- a/lib/puppet/reports/xmpp.rb
+++ b/lib/puppet/reports/xmpp.rb
@@ -16,13 +16,14 @@ Puppet::Reports.register_report(:xmpp) do
   XMPP_JID = config[:xmpp_jid]
   XMPP_PASSWORD = config[:xmpp_password]
   XMPP_TARGET = config[:xmpp_target]
+  XMPP_ENV = config[:xmpp_environment]
 
   desc <<-DESC
   Send notification of failed reports to an XMPP user.
   DESC
 
   def process
-    if self.status == 'failed'
+    if self.status == 'failed' and (XMPP_ENV.include?(self.environment) or XMPP_ENV == 'ALL')
       Puppet.debug "Sending status for #{self.host} to XMMP user #{XMPP_TARGET}"
       jid = JID::new(XMPP_JID)
       cl = Client::new(jid)


### PR DESCRIPTION
Add to conditional under the process method to filter out reports that
  came from a non specified environment.  Takes an environment string,
  an array of environments, or ALL.

  Before this I would get messages all weekend and through the nights
  because someone didn't finish hacking before being finished for the
  day.
