### PR TITLE
added password for muc channels

### DIFF
--- a/xmpp.yaml
+++ b/xmpp.yaml
@@ -17,6 +17,9 @@
 #   xmpp_muc          Wether your target is a MUC.
 #                     defaults to: false
 #
+#   xmpp_muc_password Specify a password for your MUC
+#                     defaults to: nil
+#
 #   regex             Different regex-profiles for more selective config
 #                     Every profiles starts with an ID: example1
 #                     Then every profile needs a ":test"-key/value with an


### PR DESCRIPTION
added functionality to read MUC passwords from YAML configuration file. Also added error handling support for invalid yaml types, which resulted in TypeErrors: can't convert Symbol into Integer
